### PR TITLE
Making ruby1.9 compatible

### DIFF
--- a/lib/rfactor/code.rb
+++ b/lib/rfactor/code.rb
@@ -31,7 +31,7 @@ module Rfactor
       
       new_code = ""
       
-      @code.each_with_index do |line, n|
+      @code.each_line.with_index do |line, n|
         line_number = n + 1 ##### not 0-based
         if line_number == selected_lines.first
           call_identation = extract_identation_level_from line
@@ -121,7 +121,7 @@ module Rfactor
     
     def extract_method_contents(selected_lines)
       method_contents = ""
-      @code.each_with_index do |line, n|
+      @code.each_line.with_index do |line, n|
         line_number = n + 1 ### not 0-based
         method_contents << line if selected_lines.include? line_number
       end

--- a/lib/rfactor/string_ext.rb
+++ b/lib/rfactor/string_ext.rb
@@ -2,7 +2,7 @@ class String
   
   def last_line
     number = 0
-    self.each_with_index do |line, i|
+    self.each_line.with_index do |line, i|
       number = i
     end
     number + 1


### PR DESCRIPTION
Tried running:
require 'rubygems'
require './rfactor'
CODE=%Q{
  def the_method(firstArg, secondArg)
    puts :code
    puts /to be/
    puts 'refactored'
  end

  def more()
    n = 3+2/7
    puts "other #{n}"
    n
  end
}
code = Rfactor::Code.new(CODE)
code.extract_method(:name => "common", :start => 3, :end => 5)

on both IRB1.8 and IRB1.9 and had to fix a few more each_line.with_index.
